### PR TITLE
User authentication update

### DIFF
--- a/integration/services/user.auth.spec.ts
+++ b/integration/services/user.auth.spec.ts
@@ -179,7 +179,7 @@ describe('UserAuth', () => {
 
   it('should reject a login for a non existent user.', (done) => {
     authUser(bad.req, nonExistantUser.email, password)
-      .then(test500)
+      .then(test401)
       .error(fail)
       .finally(done);
   });

--- a/src/services/user-auth.ts
+++ b/src/services/user-auth.ts
@@ -64,6 +64,10 @@ module UserAuth{
                 }
 
             }).catch(errors.UserNotFoundException, (err) => {
+                resolve(401);
+            }).catch(errors.EmailValidationException, (err) => {
+                resolve(401);
+            }).catch(Error, (err) => {
                 resolve(500);
             });
 


### PR DESCRIPTION
Fixed uncaught error in the user authentication service.  Changed the response status code for a nonexistent account to 401 to match the documentation.  Updated the integration tests to reflect these changes.
