### PR TITLE
Added a local SMTP server that is useful when developing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
     - "0.12"
-    - "0.11"
-    - "0.10"
 before_install:
   - source /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
   - wget -qO- http://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -

--- a/config.js
+++ b/config.js
@@ -33,6 +33,11 @@ var migratorTest = function() {
 }
 
 module.exports = {
+  'smtp': {
+    'port': 8081,
+    'user': 'no-reply@froyo.com',
+    'pass': 'froyo'
+  },
   'tsConfigFile': 'tsconfig.json',
   'tsconfig': tsConfig(),
   'tsd': tsd(),

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "gulp-sourcemaps": "^1.5.2",
     "gulp-tslint": "^3.0.1-beta",
     "gulp-typescript": "^2.7.3",
-    "gulp-util": "^3.0.4"
+    "gulp-util": "^3.0.4",
+    "smtp-server": "^1.4.2"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -40,16 +40,15 @@ export class Config {
    * @type {Object}
    */
   static email = {
-    //port: 465,
-    //host: 'localhost',
-    //secure: true,
+    port: 8081,
+    host: 'localhost',
+    secure: false,
     name: 'Corpool',
     auth: {
-      user: 'some@gmail.com',
-      pass: 'password'
+      user: 'no-reply@froyo.com',
+      pass: 'froyo'
     },
-    service: 'Gmail',
-    //ignoreTLS: false,
+    ignoreTLS: true
   };
 
   static docs = {


### PR DESCRIPTION
# Description

Now when you run `gulp` it will start a local SMTP server alongside the app. I updated `config.ts` file's email info to point at the local SMTP server. Now when you create a user using the REST api, the activation email will get sent to the local SMTP server and the email message will get logged in the console where you ran `gulp`.

This is useful for getting the activation code of a newly created user.

![screen shot 2015-07-11 at 2 27 40 am](https://cloud.githubusercontent.com/assets/210981/8633274/b4c1ffa2-2774-11e5-96af-ae040381e58b.png)
# NOTE

You will need node 0.12 or higher. This will not work with node 0.10.
