### PR TITLE
Yo 48

### DIFF
--- a/integration/controllers/carpool.ctrl.spec.ts
+++ b/integration/controllers/carpool.ctrl.spec.ts
@@ -380,20 +380,11 @@ describe('Carpool controller', () => {
   it('should retrieve a list of carpools', (done) => {
     var carpoolList:models.Carpool[];
 
-    //add a carpool at the same location as the req
-    //confirm that it's the first returned
-    //confirm some carpool outside of radius is NOT returned
-
     function test(status, outputJSON) {
       expect(status).toBe(200);
       expect(outputJSON.length > 0).toEqual(true);
       expect(carpoolList.length).toEqual(outputJSON.length);
       expect(carpoolList[0].name).toEqual('Closest Carpool');
-
-      //console.log(carpoolList.length);
-      //console.log(carpoolList[0].pickupLocation);
-      //console.log(carpoolList[1].pickupLocation);
-      //console.log(carpoolList[2].pickupLocation);
     }
 
     var req = <restify.Request> {params: {}};
@@ -409,14 +400,14 @@ describe('Carpool controller', () => {
 
     CarpoolSvc.createCarpool('Closest Carpool', 'PSU', 'Most convenient location ever.', owner.userName, closestCarpoolAddress)
       .then(() => {
-        return CarpoolSvc.getCarpools(10, 5, convenientLocation, 'PSU');
+        return CarpoolSvc.getCarpools(10, 5000, convenientLocation, 'PSU');
       })
       .then((_carpoolList) => {
         carpoolList = _carpoolList;
       })
       .then(() => {
         req.body = convenientLocation;
-        req.params.radius = 5;
+        req.params.radius = 5000;
         req.params.campusName = 'PSU';
         return getCarpools(req, res)
       })

--- a/integration/controllers/carpool.ctrl.spec.ts
+++ b/integration/controllers/carpool.ctrl.spec.ts
@@ -399,8 +399,8 @@ describe('Carpool controller', () => {
     var req = <restify.Request> {params: {}};
     var res = <restify.Response> {send: test};
     var convenientLocation:models.GeoCode = {
-      "lat": 45.372,
-      "long": -121.292
+      "lat": 36.121,
+      "long": -115.174
     };
     var closestCarpoolAddress = {
       "address": "Nexus of the universe",

--- a/integration/controllers/carpool.ctrl.spec.ts
+++ b/integration/controllers/carpool.ctrl.spec.ts
@@ -380,7 +380,7 @@ describe('Carpool controller', () => {
   it('should retrieve a list of carpools', (done) => {
     var carpoolList:models.Carpool[];
 
-    //add a carpool at the same location as the req (or use the PSU address?)
+    //add a carpool at the same location as the req
     //confirm that it's the first returned
     //confirm some carpool outside of radius is NOT returned
 
@@ -409,7 +409,7 @@ describe('Carpool controller', () => {
 
     CarpoolSvc.createCarpool('Closest Carpool', 'PSU', 'Most convenient location ever.', owner.userName, closestCarpoolAddress)
       .then(() => {
-        return CarpoolSvc.getCarpools(10);
+        return CarpoolSvc.getCarpools(10, 5, convenientLocation, 'PSU');
       })
       .then((_carpoolList) => {
         carpoolList = _carpoolList;
@@ -417,7 +417,7 @@ describe('Carpool controller', () => {
       .then(() => {
         req.body = convenientLocation;
         req.params.radius = 5;
-        req.params.campus = 'PSU';
+        req.params.campusName = 'PSU';
         return getCarpools(req, res)
       })
       .catch(fail)

--- a/integration/controllers/carpool.ctrl.spec.ts
+++ b/integration/controllers/carpool.ctrl.spec.ts
@@ -387,7 +387,7 @@ describe('Carpool controller', () => {
       expect(carpoolList[0].name).toEqual('Closest Carpool');
     }
 
-    var req = <restify.Request> {params: {}};
+    var req = <restify.Request> {query: {}};
     var res = <restify.Response> {send: test};
     var convenientLocation:models.GeoCode = {
       "lat": 36.121,
@@ -400,15 +400,16 @@ describe('Carpool controller', () => {
 
     CarpoolSvc.createCarpool('Closest Carpool', 'PSU', 'Most convenient location ever.', owner.userName, closestCarpoolAddress)
       .then(() => {
-        return CarpoolSvc.getCarpools(10, 5000, convenientLocation, 'PSU');
+        return CarpoolSvc.getCarpools(10, 5000, convenientLocation.long, convenientLocation.lat, 'PSU');
       })
       .then((_carpoolList) => {
         carpoolList = _carpoolList;
       })
       .then(() => {
-        req.body = convenientLocation;
-        req.params.radius = 5000;
-        req.params.campusName = 'PSU';
+        req.query.long = convenientLocation.long;
+        req.query.lat = convenientLocation.lat;
+        req.query.radius = 5000;
+        req.query.campusName = 'PSU';
         return getCarpools(req, res)
       })
       .catch(fail)

--- a/integration/dbutils/migrator.spec.ts
+++ b/integration/dbutils/migrator.spec.ts
@@ -21,7 +21,7 @@ var dbShape : Shapes.DBShape = {
   },
   {
     tableName: 'carpools',
-    indices: ['name', 'pickupLocation.geoCode']
+    indices: ['name', 'pickupLocation.geoCode', 'geoPoint']
   },
   {
     tableName: 'campuses',
@@ -73,11 +73,11 @@ describe('Database Migrator', () => {
   var fail = (error) => {expect(error).toBeUndefined();};
   var testTrue = (result) => {expect(result).toBe(true);};
 
-  it('should have the same databse shape as described in this test', () => {
+  it('should have the same database shape as described in this test', () => {
     expect(dbShape).toEqual(Migrator.Migrator.dbShape);
   });
 
-  it('should have created databse ' + dbShape.dbname, (done) => {
+  it('should have created database ' + dbShape.dbname, (done) => {
     r.dbList()
       .contains(dbShape.dbname)
       .run(conn)

--- a/src/controllers/carpool.ctrl.ts
+++ b/src/controllers/carpool.ctrl.ts
@@ -96,8 +96,12 @@ module CarpoolController {
   export function getCarpools(
     req:restify.Request, res:restify.Response, next:restify.Next) {
     function getCarpoolList() {
+      var radius:number = parseFloat(req.query.radius);
+      var long:number = parseFloat(req.query.long);
+      var lat:number = parseFloat(req.query.lat);
+      var campusName:string = req.query.campusName;
 
-      return carpoolService.getCarpools(10, req.query.radius, req.query.long, req.query.lat, req.query.campusName);
+      return carpoolService.getCarpools(10, radius, long, lat, campusName);
     }
 
     getCarpoolList()

--- a/src/controllers/carpool.ctrl.ts
+++ b/src/controllers/carpool.ctrl.ts
@@ -1,5 +1,6 @@
-import restify = require('restify')
-import carpoolService = require('../services/carpool.svc')
+import restify = require('restify');
+import r = require('rethinkdb');
+import carpoolService = require('../services/carpool.svc');
 import userCtrl = require('./create-user.ctrl');
 import userService = require('../services/user-service');
 import campusCtrl = require('./campus.ctrl');
@@ -128,6 +129,9 @@ module CarpoolController {
       carpoolUpdate = addFieldFromJSON(requestBody, carpoolUpdate, "name");
       carpoolUpdate = addFieldFromJSON(requestBody, carpoolUpdate, "description");
       carpoolUpdate = addFieldFromJSON(requestBody, carpoolUpdate, "pickupLocation");
+      if(requestBody.pickupLocation) {
+        carpoolUpdate['geoPoint'] = r.point(requestBody.pickupLocation.geoCode.long, requestBody.pickupLocation.geoCode.lat);
+      }
       if(requestBody.campus) {
         carpoolUpdate["campus"] = getIDFromHref(requestBody.campus);
       }

--- a/src/controllers/carpool.ctrl.ts
+++ b/src/controllers/carpool.ctrl.ts
@@ -95,7 +95,7 @@ module CarpoolController {
   export function getCarpools(
     req:restify.Request, res:restify.Response, next:restify.Next) {
     function getCarpoolList() {
-      return carpoolService.getCarpools(10);
+      return carpoolService.getCarpools(10, req.params.radius, req.body, req.params.campusName);
     }
 
     getCarpoolList()

--- a/src/controllers/carpool.ctrl.ts
+++ b/src/controllers/carpool.ctrl.ts
@@ -96,7 +96,8 @@ module CarpoolController {
   export function getCarpools(
     req:restify.Request, res:restify.Response, next:restify.Next) {
     function getCarpoolList() {
-      return carpoolService.getCarpools(10, req.params.radius, req.body, req.params.campusName);
+
+      return carpoolService.getCarpools(10, req.query.radius, req.query.long, req.query.lat, req.query.campusName);
     }
 
     getCarpoolList()

--- a/src/dbutils/migrator.ts
+++ b/src/dbutils/migrator.ts
@@ -19,7 +19,7 @@ module DBUtils {
       },
       {
         tableName: 'carpools',
-        indices: ['name', 'pickupLocation.geoCode']
+        indices: ['name', 'pickupLocation.geoCode', 'geoPoint']
       },
       {
         tableName: 'campuses',
@@ -69,7 +69,7 @@ module DBUtils {
         var createIndex = (i: string) => {
           var test = r.db(Migrator.dbShape.dbname).table(table.tableName).indexList().contains(i);
           var trueBranch = r.now();
-          var falseBranch = r.db(Migrator.dbShape.dbname).table(table.tableName).indexCreate(i);
+          var falseBranch = (i == 'geoPoint')? r.db(Migrator.dbShape.dbname).table(table.tableName).indexCreate(i, {geo:true}) : r.db(Migrator.dbShape.dbname).table(table.tableName).indexCreate(i);
           return r.branch(test, trueBranch, falseBranch).run(this._conn);
         };
         return p.map(table.indices, createIndex);

--- a/src/server.ts
+++ b/src/server.ts
@@ -56,6 +56,7 @@ server.use(sessions({
 // Restify body parser provides all of the info sent to the route
 // in a JSON object.
 server.use(restify.bodyParser());
+server.use(restify.queryParser());
 
 var routes = new (require('./routes'))(server);
 

--- a/src/services/carpool.svc.ts
+++ b/src/services/carpool.svc.ts
@@ -85,7 +85,8 @@ module CarpoolService {
           'participants': [carpool.owner.id],
           'campus': carpool.campus.id,
           'description': carpool.description,
-          'pickupLocation': carpool.pickupLocation
+          'pickupLocation': carpool.pickupLocation,
+          'geoPoint':r.point(carpool.pickupLocation.geoCode.long,carpool.pickupLocation.geoCode.lat)
         });
 
       // Note: Even though buildCarpoolModel ensure campus and user exist,
@@ -173,7 +174,7 @@ module CarpoolService {
   export function getCarpools(limit: number, radius: number, location:models.GeoCode, campusName: string) :  Promise<models.Carpool[]> {
     var _db = r.db(db);
     var query = _db.table(table).getNearest(r.point(location.long,location.lat),{
-      index: 'pickupLocation.geoCode', maxDist:radius //todo: need to create a geospatial index from geoCode field....
+      index: 'geoPoint', maxDist:radius //todo: need to create a geospatial index from geoCode field....
     }).limit(limit).merge({
       'campus': _db.table('campuses').get(r.row('campus')),
       'owner': _db.table('users').get(r.row('owner')),

--- a/src/services/carpool.svc.ts
+++ b/src/services/carpool.svc.ts
@@ -174,8 +174,8 @@ module CarpoolService {
   export function getCarpools(limit: number, radius: number, location:models.GeoCode, campusName: string) :  Promise<models.Carpool[]> {
     var _db = r.db(db);
     var query = _db.table(table).getNearest(r.point(location.long,location.lat),{
-      index: 'geoPoint', maxDist:radius //todo: need to create a geospatial index from geoCode field....
-    }).limit(limit).merge({
+      index: 'geoPoint', maxDist:radius
+    }).limit(limit).getField('doc').merge({
       'campus': _db.table('campuses').get(r.row('campus')),
       'owner': _db.table('users').get(r.row('owner')),
       'participants': r.row('participants').map((p) => {

--- a/src/services/carpool.svc.ts
+++ b/src/services/carpool.svc.ts
@@ -170,9 +170,11 @@ module CarpoolService {
   }
 
   // This should take a limit as an argument and return no more than that number of carpools.
-  export function getCarpools(limit: number) :  Promise<models.Carpool[]> {
+  export function getCarpools(limit: number, radius: number, location:models.GeoCode, campusName: string) :  Promise<models.Carpool[]> {
     var _db = r.db(db);
-    var query = _db.table(table).limit(limit).merge({
+    var query = _db.table(table).getNearest(r.point(location.long,location.lat),{
+      index: 'pickupLocation.geoCode', maxDist:radius //todo: need to create a geospatial index from geoCode field....
+    }).limit(limit).merge({
       'campus': _db.table('campuses').get(r.row('campus')),
       'owner': _db.table('users').get(r.row('owner')),
       'participants': r.row('participants').map((p) => {

--- a/src/services/carpool.svc.ts
+++ b/src/services/carpool.svc.ts
@@ -174,8 +174,8 @@ module CarpoolService {
   export function getCarpools(limit: number, radius: number, location:models.GeoCode, campusName: string) :  Promise<models.Carpool[]> {
     var _db = r.db(db);
     var query = _db.table(table).getNearest(r.point(location.long,location.lat),{
-      index: 'geoPoint', maxDist:radius
-    }).limit(limit).getField('doc').merge({
+      index: 'geoPoint', maxResults: limit, maxDist:radius, unit: 'mi'
+    }).getField('doc').merge({
       'campus': _db.table('campuses').get(r.row('campus')),
       'owner': _db.table('users').get(r.row('owner')),
       'participants': r.row('participants').map((p) => {

--- a/src/services/carpool.svc.ts
+++ b/src/services/carpool.svc.ts
@@ -171,7 +171,14 @@ module CarpoolService {
   }
 
   // This should take a limit as an argument and return no more than that number of carpools.
-  export function getCarpools(limit: number, radius: number, long: number, lat: number, campusName: string) :  Promise<models.Carpool[]> {
+  export function getCarpools(
+    limit: number,
+    radius: number,
+    long: number,
+    lat: number,
+    campusName: string
+  ) :  Promise<models.Carpool[]> {
+
     var _db = r.db(db);
     var query = _db.table(table).getNearest(r.point(long,lat),{
       index: 'geoPoint', maxResults: limit, maxDist:radius, unit: 'mi'
@@ -181,6 +188,10 @@ module CarpoolService {
       'participants': r.row('participants').map((p) => {
         return _db.table('users').get(p);
       })
+    }).filter({
+      campus: {
+        name: campusName
+      }
     }).coerceTo('array');
 
     return q.run(query, 'getCarpools')()

--- a/src/services/carpool.svc.ts
+++ b/src/services/carpool.svc.ts
@@ -171,9 +171,9 @@ module CarpoolService {
   }
 
   // This should take a limit as an argument and return no more than that number of carpools.
-  export function getCarpools(limit: number, radius: number, location:models.GeoCode, campusName: string) :  Promise<models.Carpool[]> {
+  export function getCarpools(limit: number, radius: number, long: number, lat: number, campusName: string) :  Promise<models.Carpool[]> {
     var _db = r.db(db);
-    var query = _db.table(table).getNearest(r.point(location.long,location.lat),{
+    var query = _db.table(table).getNearest(r.point(long,lat),{
       index: 'geoPoint', maxResults: limit, maxDist:radius, unit: 'mi'
     }).getField('doc').merge({
       'campus': _db.table('campuses').get(r.row('campus')),

--- a/swagger/docs/swagger.json
+++ b/swagger/docs/swagger.json
@@ -216,22 +216,53 @@
                     }
                 }
             },
-          "get": {
-            "summary": "\n Returns all Carpools.",
-            "description": "\n This end point returns an array of Carpools.",
-            "tags": ["Carpool"],
-            "responses": {
-                "200": {
-                    "description": "Retrieves list of carpools",
-                    "schema": {
-                        "$ref": "#/definitions/Carpool"
+
+            "get": {
+                "summary": "\n Returns all Carpools.",
+                "description": "\n This end point returns an array of Carpools.",
+                "parameters": [
+                    {
+                        "name": "radius",
+                        "in": "query",
+                        "description": "Max distance from user's location to return carpools",
+                        "required": true,
+                        "type": "number"
+                    },
+                    {
+                        "name": "campusName",
+                        "in": "query",
+                        "description": "Campus that user belongs to",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "long",
+                        "in": "query",
+                        "description": "Longitude coordinate for user's location",
+                        "required": true,
+                        "type": "number"
+                    },
+                    {
+                        "name": "lat",
+                        "in": "query",
+                        "description": "Latitude coordinate for user's location",
+                        "required": true,
+                        "type": "number"
                     }
-                },
-                "500": {
-                    "description": "Internal server error."
+                ],
+                "tags": ["Carpool"],
+                "responses": {
+                    "200": {
+                        "description": "Retrieves list of carpools",
+                        "schema": {
+                            "$ref": "#/definitions/Carpool"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error."
+                    }
                 }
-            }
-          }
+                }
         },
         "/api/carpools/{carpoolid}": {
             "get": {
@@ -581,7 +612,6 @@
             "required": [
                 "carpoolID",
                 "userToDenyID"
-
             ],
             "properties" : {
                 "carpoolID" : { "required": true, "type" :"string"},

--- a/typings/rethinkdb/rethinkdb.d.ts
+++ b/typings/rethinkdb/rethinkdb.d.ts
@@ -29,6 +29,7 @@ declare module "rethinkdb" {
 
   export function row(name:string):Expression<any>;
   export function expr(stuff:any):Expression<any>;
+  export function point(x:number,y:number);
 
   export function now():Expression<any>;
   export function args(list:string[]):Expression<any>;
@@ -142,6 +143,7 @@ declare module "rethinkdb" {
     isEmpty():Expression<boolean>;
     union(sequence:Sequence):Sequence;
     sample(n:number):Sequence;
+    getNearest(point:any,params:any):Sequence;
 
     // Aggregate
     reduce(r:ReduceFunction<any>, base?:any):Expression<any>;

--- a/typings/rethinkdb/rethinkdb.d.ts
+++ b/typings/rethinkdb/rethinkdb.d.ts
@@ -120,6 +120,7 @@ declare module "rethinkdb" {
     filter(obj:{[key:string]:any}):Sequence;
     merge(any);
     getField(a:string):Expression<any>;
+    getField(a:string):Sequence;
     forEach(a:any):any;
 
     // Join
@@ -220,6 +221,7 @@ declare module "rethinkdb" {
       map(a:any):Expression<any>;
       map(transform:ExpressionFunction<any>):Sequence;
       merge(query:Expression<Object>):Expression<Object>;
+      merge(query:any):any;
       append(prop:string):Expression<Object>;
       contains(prop:string):Expression<boolean>;
       contains(expr:Expression<any>):Expression<boolean>;

--- a/typings/rethinkdb/rethinkdb.d.ts
+++ b/typings/rethinkdb/rethinkdb.d.ts
@@ -29,7 +29,7 @@ declare module "rethinkdb" {
 
   export function row(name:string):Expression<any>;
   export function expr(stuff:any):Expression<any>;
-  export function point(x:number,y:number);
+  export function point(longitude:number,latitude:number):Point;
 
   export function now():Expression<any>;
   export function args(list:string[]):Expression<any>;
@@ -95,6 +95,7 @@ declare module "rethinkdb" {
 
   interface Table extends Sequence {
     indexCreate(name:string, index?:ExpressionFunction<any>):Expression<any>;
+    indexCreate(name:string, options:{multi?:boolean;geo?:boolean}):Expression<any>;
     indexDrop(name:string):Operation<DropResult>;
     indexList():Expression<any>;
 
@@ -257,6 +258,11 @@ declare module "rethinkdb" {
   interface Sort {}
 
   interface Time {}
+
+  interface Point {
+    longitude: number;
+    latitude: number;
+  }
 
 
   // http://www.rethinkdb.com/api/#js


### PR DESCRIPTION
### Description
- Updated `api/carpools` endpoint to return a list of the closest carpools by doing a GET with query parameters: `radius`, `campusName`, `lat` and `long`
- Updated `getCarpools()` method in carpool service
- Updated integration test for `getCarpools()` method
- Updated swagger docs

Example GET: `api/carpools?radius=5000&campusName=PSU&long=-115&lat=36`
Will return the list of carpools in order of closest to the location: latitude 36, longitude -115, and will only include carpools within 5000 miles that are associated with the PSU campus.
